### PR TITLE
Add: logger&cli&server modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target
+/Cargo.lock
+.vscode
+logs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ping-viewer-next"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+actix-web = "4.6.0"
+chrono = "0.4.38"
+clap = {version = "4.5.4", features = ["derive"] }
+lazy_static = "1.4.0"
+paperclip = { version = "0.8.2" , features = ["actix4", "swagger-ui", "uuid"] }
+tokio = { version = "1.37.0", features = ["full"] }
+tracing = { version = "0.1.40", features = ["log", "async-await"] }
+tracing-log = "0.2.0"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-appender = { git = "https://github.com/joaoantoniocardoso/tracing", branch = "tracing-appender-0.2.2-with-filename-suffix" }
+tracing-tracy = "0.11.0"
+
+[build-dependencies]
+vergen-gix = { version = "1.0.0-beta.2", default-features = false, features = ["build", "cargo"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+use vergen_gix::{BuildBuilder, CargoBuilder, DependencyKind, GixBuilder};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    vergen_gix::Emitter::default()
+        .add_instructions(&BuildBuilder::all_build()?)?
+        .add_instructions(&GixBuilder::all_git()?)?
+        .add_instructions(
+            CargoBuilder::all_cargo()?
+                .set_dep_kind_filter(Some(DependencyKind::Normal)),
+        )?
+        .emit()?;
+    Ok(())
+}

--- a/src/cli/manager.rs
+++ b/src/cli/manager.rs
@@ -1,0 +1,107 @@
+use clap;
+use std::sync::Arc;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"), about = env!("CARGO_PKG_DESCRIPTION"))]
+struct Args {
+    /// Deletes settings file before starting.
+    #[arg(long)]
+    reset: bool,
+
+    /// Sets the address for the REST API server
+    #[arg(long, value_name = "IP>:<PORT", default_value = "0.0.0.0:8080")]
+    rest_server: String,
+
+    /// Turns all log categories up to Debug, for more information check RUST_LOG env variable.
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Specifies the path in witch the logs will be stored.
+    #[arg(long, default_value = "./logs")]
+    log_path: Option<String>,
+
+    /// Turns all log categories up to Trace to the log file, for more information check RUST_LOG env variable.
+    #[arg(long)]
+    enable_tracing_level_log_file: bool,
+
+    /// Filter to show only own crate related logs
+    #[arg(long, default_value = "false")]
+    log_current_crate_only: bool,
+
+    /// Turns on the Tracy tool integration.
+    #[arg(long)]
+    enable_tracy: bool,
+}
+
+#[derive(Debug)]
+struct Manager {
+    clap_matches: Args,
+}
+
+lazy_static! {
+    static ref MANAGER: Arc<Manager> = Arc::new(Manager::new());
+}
+
+impl Manager {
+    fn new() -> Self {
+        Self {
+            clap_matches: Args::parse(),
+        }
+    }
+}
+
+// Construct our manager, should be done inside main
+pub fn init() {
+    MANAGER.as_ref();
+}
+
+// Check if the verbosity parameter was used
+pub fn is_verbose() -> bool {
+    MANAGER.clap_matches.verbose
+}
+
+pub fn is_tracing() -> bool {
+    MANAGER.clap_matches.enable_tracing_level_log_file
+}
+
+pub fn is_tracy() -> bool {
+    MANAGER.clap_matches.enable_tracy
+}
+
+pub fn log_current_crate_only() -> bool {
+    MANAGER.clap_matches.log_current_crate_only
+}
+
+pub fn log_path() -> String {
+    MANAGER
+        .clap_matches
+        .log_path
+        .clone()
+        .expect("Clap arg \"log-path\" should always be \"Some(_)\" because of the default value.")
+}
+
+// Return the desired address for the REST API
+pub fn server_address() -> String {
+    MANAGER.clap_matches.rest_server.clone()
+}
+
+// Return the command line used to start this application
+pub fn command_line_string() -> String {
+    std::env::args().collect::<Vec<String>>().join(" ")
+}
+
+// Return a clone of current Args struct
+pub fn command_line() -> String {
+    format!("{:#?}", MANAGER.clap_matches)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_arguments() {
+        assert!(!is_verbose());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,1 @@
+pub mod manager;

--- a/src/logger/manager.rs
+++ b/src/logger/manager.rs
@@ -1,0 +1,116 @@
+use std::str::FromStr;
+
+use crate::cli;
+
+use tracing::{metadata::LevelFilter, *};
+use tracing_log::LogTracer;
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Layer};
+
+// Start logger, should be done inside main
+pub fn init() {
+    // Redirect all logs from libs using "Log"
+    LogTracer::init_with_filter(tracing::log::LevelFilter::Trace).expect("Failed to set logger");
+
+    let level = std::env::var("RUST_LOG").unwrap_or_else(|_| {
+        if cli::manager::is_verbose() {
+            LevelFilter::DEBUG.to_string()
+        } else {
+            LevelFilter::INFO.to_string()
+        }
+    });
+
+    let console_env_filter = EnvFilter::from_str(&level).expect("logger : Invalid debugging value");
+
+    let console_layer = fmt::Layer::new()
+        .with_writer(std::io::stdout)
+        .with_ansi(true)
+        .with_file(true)
+        .with_line_number(true)
+        .with_span_events(fmt::format::FmtSpan::NONE)
+        .with_target(false)
+        .with_thread_ids(true)
+        .with_thread_names(true)
+        .with_filter(console_env_filter);
+
+    // Configure the file log
+    let file_env_filter = if cli::manager::is_tracing() {
+        EnvFilter::new(LevelFilter::TRACE.to_string())
+    } else {
+        EnvFilter::new(LevelFilter::DEBUG.to_string())
+    };
+
+    let dir = cli::manager::log_path();
+    let file_appender = tracing_appender::rolling::hourly(dir, "ping-viewer.", ".log");
+    let file_layer = fmt::Layer::new()
+        .with_writer(file_appender)
+        .with_ansi(false)
+        .with_file(true)
+        .with_line_number(true)
+        .with_span_events(fmt::format::FmtSpan::NONE)
+        .with_target(false)
+        .with_thread_ids(true)
+        .with_thread_names(true)
+        .with_filter(file_env_filter);
+
+    let subscriber = tracing_subscriber::registry()
+        .with(console_layer)
+        .with(file_layer);
+
+    // Configure the default subscriber
+    match (
+        cli::manager::is_tracy(),
+        cli::manager::log_current_crate_only(),
+    ) {
+        (true, true) => {
+            let subscriber = subscriber.with(EnvFilter::new(format!(
+                "{}={level}",
+                env!("CARGO_PKG_NAME").replace('-', "_")
+            )));
+            let tracy_layer = tracing_tracy::TracyLayer::default();
+            let subscriber = subscriber.with(tracy_layer);
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("Unable to set a global subscriber");
+        }
+        (false, true) => {
+            let subscriber = subscriber.with(EnvFilter::new(format!(
+                "{}={level}",
+                env!("CARGO_PKG_NAME").replace('-', "_")
+            )));
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("Unable to set a global subscriber");
+        }
+        (true, false) => {
+            let tracy_layer = tracing_tracy::TracyLayer::default();
+            let subscriber = subscriber.with(tracy_layer);
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("Unable to set a global subscriber");
+        }
+        (false, false) => {
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("Unable to set a global subscriber");
+        }
+    };
+
+    info!(
+        "{}, version: {}-{}, build date: {}",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+        env!("VERGEN_GIT_SHA"),
+        env!("VERGEN_BUILD_DATE")
+    );
+
+    info!(
+        "Build dependencies details: {}",
+        env!("VERGEN_CARGO_DEPENDENCIES"),
+    );
+
+    info!(
+        "Starting at {}",
+        chrono::Local::now().format("%Y-%m-%dT%H:%M:%S"),
+    );
+    debug!("Command line call: {}", cli::manager::command_line_string());
+    debug!(
+        "Command line input struct call: {}",
+        cli::manager::command_line()
+    );
+}

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -1,0 +1,1 @@
+pub mod manager;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,18 @@
+#[macro_use]
+extern crate lazy_static;
+
+mod cli;
+mod logger;
+mod server;
+
+#[tokio::main]
+async fn main() {
+    // CLI should be started before logger to allow control over verbosity
+    cli::manager::init();
+    // Logger should start before everything else to register any log information
+    logger::manager::init();
+
+    server::manager::run(&cli::manager::server_address())
+        .await
+        .unwrap();
+}

--- a/src/server/manager.rs
+++ b/src/server/manager.rs
@@ -1,0 +1,19 @@
+use actix_web::{middleware, App, HttpServer};
+use paperclip::actix::OpenApiExt;
+use tracing::info;
+
+pub async fn run(server_address: &str) -> std::io::Result<()> {
+    let server_address = server_address.to_string();
+    info!("starting HTTP server at http://{server_address}");
+
+    let server = HttpServer::new(|| {
+        App::new()
+            .wrap(middleware::Logger::default())
+            .wrap_api()
+            .with_json_spec_at("/api/spec")
+            .with_swagger_ui_at("/docs")
+            .build()
+    });
+
+    server.bind(server_address)?.run().await
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,0 +1,1 @@
+pub mod manager;


### PR DESCRIPTION
Refs:
https://github.com/mavlink/mavlink-camera-manager
https://github.com/bluerobotics/navigator-web-assistant
https://github.com/rustyhorde/vergen
https://github.com/rustyhorde/vergen/blob/master/MIGRATING_v8_to_v9.md
https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html

Logs as /logs/ping-viewer.2024-05-30-19.log
*Sync with latest vergen 9.0 versions - through beta version with "gix flavour",
*Shows building dependencies:
![image](https://github.com/bluerobotics/ping-viewer-next/assets/80598030/cdc22485-8011-4510-aa1b-c7f1b799c610)*Supress outside crate dependencies logs with  --log_current_crate_only=false

*( Todo! A new filter with different levels for each dependency)  using vergen dependencies list - could be usefull for mavlink and mavlink2rest.