### PR TITLE
Add: AutoCreate method for DeviceManager

### DIFF
--- a/src/cli/manager.rs
+++ b/src/cli/manager.rs
@@ -5,6 +5,10 @@ use std::sync::Arc;
 #[derive(Parser, Debug)]
 #[command(version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"), about = env!("CARGO_PKG_DESCRIPTION"))]
 struct Args {
+    /// Call AutoCreate on DeviceManager during application startup.
+    #[arg(long, default_value = "false")]
+    enable_auto_create: bool,
+
     /// Deletes settings file before starting.
     #[arg(long)]
     reset: bool,
@@ -71,6 +75,10 @@ pub fn is_tracy() -> bool {
 
 pub fn log_current_crate_only() -> bool {
     MANAGER.clap_matches.log_current_crate_only
+}
+
+pub fn is_enable_auto_create() -> bool {
+    MANAGER.clap_matches.enable_auto_create
 }
 
 pub fn log_path() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,14 +16,17 @@ async fn main() {
     // Logger should start before everything else to register any log information
     logger::manager::init();
 
-    let (manager, handler) = device::manager::DeviceManager::new(10);
-    tokio::spawn(async move { manager.run().await });
+    let (mut manager, handler) = device::manager::DeviceManager::new(10);
 
     //Todo: Load previous devices
-    info!(
-        "DeviceManager initialized with following devices: {:?}",
-        handler.send(crate::device::manager::Request::List).await
-    );
+    if cli::manager::is_enable_auto_create() {
+        match manager.auto_create().await {
+            Ok(answer) => info!("DeviceManager initialized with following devices: {answer:?}"),
+            Err(err) => info!("DeviceManager unable to initialize with devices, details {err:?}"),
+        }
+    }
+
+    tokio::spawn(async move { manager.run().await });
 
     server::manager::run(&cli::manager::server_address(), handler)
         .await


### PR DESCRIPTION
Needs:

- [x] https://github.com/bluerobotics/ping-viewer-next/pull/7

Details:

```
pi@raspbian-armv7-kernel-5:~/deploy $ ./ping-viewer-next --log-current-crate-only --enable-auto-create
2024-08-01T19:58:37.269940Z  INFO main ThreadId(01) src/logger/manager.rs:94: ping-viewer-next, version: 0.0.0-17c4ed001ee17f263ef4cd5f50b9d13bead8f7b5, build date: 2024-08-01
2024-08-01T19:58:37.270141Z  INFO main ThreadId(01) src/logger/manager.rs:102: Build dependencies details: actix 0.13.5,actix-web 4.6.0,actix-web-actors 4.3.0,bluerobotics-ping 0.3.0,chrono 0.4.38,clap 4.5.4,lazy_static 1.4.0,mime_guess 2.0.5,paperclip 0.8.2,regex 1.10.5,rust-embed 8.5.0,serde 1.0.202,serde_json 1.0.117,thiserror 1.0.61,tokio 1.38.0,tokio-serial 5.4.4,tracing 0.1.40,tracing-appender 0.2.2-with-filename-suffix,tracing-log 0.2.0,tracing-subscriber 0.3.18,tracing-tracy 0.11.0,udp-stream 0.0.12,uuid 1.8.0,validator 0.18.1
2024-08-01T19:58:37.270404Z  INFO main ThreadId(01) src/logger/manager.rs:107: Starting at 2024-08-01T20:58:37
2024-08-01T19:58:37.562689Z  INFO main ThreadId(01) src/device/manager.rs:384: New device created and available, details: DeviceInfo([DeviceInfo { id: 00000000-0000-0000-6113-f5df77d4fbd6, source: SerialStream(SourceSerialStruct { path: "/dev/ttyUSB1", baudrate: 115200 }), status: ContinuousMode, device_type: Ping1D }])
2024-08-01T19:58:37.675212Z  INFO main ThreadId(01) src/device/manager.rs:384: New device created and available, details: DeviceInfo([DeviceInfo { id: 00000000-0000-0000-1cc4-7b702224f52d, source: SerialStream(SourceSerialStruct { path: "/dev/ttyUSB0", baudrate: 115200 }), status: ContinuousMode, device_type: Ping1D }])
2024-08-01T19:58:37.675329Z  INFO main ThreadId(01) src/main.rs:24: DeviceManager initialized with following devices: DeviceInfo([DeviceInfo { id: 00000000-0000-0000-6113-f5df77d4fbd6, source: SerialStream(SourceSerialStruct { path: "/dev/ttyUSB1", baudrate: 115200 }), status: ContinuousMode, device_type: Ping1D }, DeviceInfo { id: 00000000-0000-0000-1cc4-7b702224f52d, source: SerialStream(SourceSerialStruct { path: "/dev/ttyUSB0", baudrate: 115200 }), status: ContinuousMode, device_type: Ping1D }])
2024-08-01T19:58:37.675418Z  INFO main ThreadId(01) src/server/manager.rs:18: ServerManager: Service starting
2024-08-01T19:58:37.675482Z  INFO tokio-runtime-worker ThreadId(02) src/device/manager.rs:250: DeviceManager is running
2024-08-01T19:58:37.676011Z  INFO                 main ThreadId(01) src/server/manager.rs:37: ServerManager: HTTP server running at http://0.0.0.0:8080

```