### PR TITLE
Upgrade: Sync to use current tracing-append crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio-serial = "5.4.4"
 tracing = { version = "0.1.40", features = ["log", "async-await"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tracing-appender = { git = "https://github.com/joaoantoniocardoso/tracing", branch = "tracing-appender-0.2.2-with-filename-suffix" }
+tracing-appender = "0.2.3"
 tracing-tracy = "0.11.0"
 udp-stream = "0.0.12"
 uuid = { version = "1.8", features = ["serde"] }

--- a/src/logger/manager.rs
+++ b/src/logger/manager.rs
@@ -40,7 +40,12 @@ pub fn init() {
     };
 
     let dir = cli::manager::log_path();
-    let file_appender = tracing_appender::rolling::hourly(dir, "ping-viewer.", ".log");
+    let file_appender = custom_rolling_appender(
+        dir,
+        tracing_appender::rolling::Rotation::HOURLY,
+        "ping-viewer",
+        "log",
+    );
     let file_layer = fmt::Layer::new()
         .with_writer(file_appender)
         .with_ansi(false)
@@ -113,4 +118,19 @@ pub fn init() {
         "Command line input struct call: {}",
         cli::manager::command_line()
     );
+}
+
+// Exclusive to output log-file with 'ping-viewer.2024-09-10-18.log' format.
+fn custom_rolling_appender<P: AsRef<std::path::Path>>(
+    dir: P,
+    rotation: tracing_appender::rolling::Rotation,
+    prefix: &str,
+    suffix: &str,
+) -> tracing_appender::rolling::RollingFileAppender {
+    tracing_appender::rolling::RollingFileAppender::builder()
+        .rotation(rotation)
+        .filename_prefix(prefix)
+        .filename_suffix(suffix)
+        .build(dir)
+        .expect("failed to initialize rolling file appender")
 }


### PR DESCRIPTION
Still produces the same required output:
![image](https://github.com/user-attachments/assets/5bba5302-b0bc-4e14-91c7-18837317b90c)

Allow the crate to publish modules/lib and share resources.