### PR TITLE
ping-viewer-next-desktop: Embed frontend to dekstop App

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,6 @@ path = "src/main.rs"
 
 [features]
 default = []
-desktop-app = ["tauri"]
+desktop-app = ["tauri", "build-frontend"]
 build-frontend = ["embed-frontend"]
 embed-frontend =[]


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8c9ed88a-6bfa-4589-ac9f-db5560031046)
