### PR TITLE
Add: Auto_baudrate to device discovery process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 [dependencies]
 actix = "0.13.3"
 actix-web = "4.9.0"
-bluerobotics-ping = "0.3.0"
+bluerobotics-ping = "0.3.3"
 actix-web-actors = "4.3.0"
 chrono = "0.4.38"
 clap = {version = "4.5.17", features = ["derive"] }

--- a/src/device/manager/device_discovery.rs
+++ b/src/device/manager/device_discovery.rs
@@ -1,9 +1,13 @@
-use std::net::Ipv4Addr;
+use std::{net::Ipv4Addr, time::Duration};
 
-use tokio_serial::available_ports;
-use tracing::warn;
+use tokio::{io::AsyncWriteExt, task::JoinSet, time::timeout};
+use tokio_serial::{available_ports, SerialPort, SerialPortBuilderExt, SerialStream};
+use tracing::{debug, error, info, trace, warn};
+
+use crate::device::manager::ManagerError;
 
 use super::{SourceSelection, SourceSerialStruct, SourceUdpStruct};
+use std::collections::HashMap;
 
 #[derive(Debug, PartialEq)]
 pub struct DiscoveryResponse {
@@ -142,18 +146,47 @@ pub fn network_discovery() -> Option<Vec<SourceSelection>> {
     Some(available_sources)
 }
 
-pub fn serial_discovery() -> Option<Vec<SourceSelection>> {
+pub async fn serial_discovery() -> Option<Vec<SourceSelection>> {
     match available_ports() {
         Ok(serial_ports) => {
-            let mut available_sources = Vec::new();
-            for port_info in serial_ports {
-                let source = SourceSelection::SerialStream(SourceSerialStruct {
-                    path: port_info.port_name.clone(),
-                    baudrate: 115200,
+            debug!("serial_discovery: Found {serial_ports:?}");
+
+            let mut set: JoinSet<Result<SourceSelection, ManagerError>> = JoinSet::new();
+
+            serial_ports.into_iter().for_each(|port_info| {
+                let path = port_info.port_name.clone();
+                set.spawn(async move {
+                    let baud_rate = auto_detect_baudrate(path.clone()).await?;
+
+                    Ok(SourceSelection::SerialStream(SourceSerialStruct {
+                        path,
+                        baudrate: baud_rate,
+                    }))
                 });
-                available_sources.push(source);
+            });
+
+            let mut available_sources = Vec::new();
+            while let Some(result) = set.join_next().await {
+                match result {
+                    Ok(Ok(source)) => {
+                        available_sources.push(source);
+                    }
+                    Ok(Err(e)) => {
+                        error!("serial_discovery: Port detection error: {e:?}");
+                    }
+                    Err(e) => {
+                        error!("serial_discovery: Task error: {e:?}");
+                    }
+                }
             }
-            Some(available_sources)
+
+            if available_sources.is_empty() {
+                warn!("serial_discovery: No valid serial devices were found");
+                None
+            } else {
+                info!("serial_discovery: Devices Available : {available_sources:?}");
+                Some(available_sources)
+            }
         }
         Err(err) => {
             warn!("Auto create: Unable to find available devices on serial ports, details: {err}");
@@ -161,6 +194,249 @@ pub fn serial_discovery() -> Option<Vec<SourceSelection>> {
         }
     }
 }
+
+async fn auto_detect_baudrate(path: String) -> Result<u32, ManagerError> {
+    const BAUDRATE_CHECK_MESSAGES: usize = 10;
+    const TOTAL_CHECK_TIMEOUT_MS: u64 = 2000;
+
+    let baud_rates = [
+        2500000, 2000000, 1843200, 921600, 460800, 230400, 115200, 9600,
+    ];
+    let mut baudrate_results: HashMap<u32, BaudrateCheckResult> = HashMap::new();
+
+    for &rate in &baud_rates {
+        debug!("auto_detect_baudrate: Testing baud rate: {}", rate);
+
+        let mut serial_stream = match tokio_serial::new(path.clone(), rate).open_native_async() {
+            Ok(stream) => stream,
+            Err(err) => {
+                warn!(
+                    "auto_detect_baudrate: Failed to open port at {}: {}",
+                    rate, err
+                );
+                continue;
+            }
+        };
+
+        #[cfg(unix)]
+        if let Err(e) = serial_stream.set_exclusive(false) {
+            warn!(
+                "auto_detect_baudrate: Failed to set non-exclusive mode: {}",
+                e
+            );
+            continue;
+        }
+
+        if let Err(e) = set_baudrate_pre_routine(&mut serial_stream, rate).await {
+            warn!(
+                "auto_detect_baudrate: Failed baudrate initialization at {}: {:?}",
+                rate, e
+            );
+            continue;
+        }
+
+        let temp_device = bluerobotics_ping::common::Device::new(serial_stream);
+
+        match timeout(
+            Duration::from_millis(TOTAL_CHECK_TIMEOUT_MS),
+            test_baudrate_quality(&temp_device, BAUDRATE_CHECK_MESSAGES),
+        )
+        .await
+        {
+            Ok(Ok(result)) => {
+                if result.parser_errors == 0 && result.messages_received == BAUDRATE_CHECK_MESSAGES
+                {
+                    info!("auto_detect_baudrate: Found optimal baudrate: {}", rate);
+                    return Ok(rate);
+                }
+                if result.messages_received > 0 {
+                    baudrate_results.insert(rate, result);
+                }
+            }
+            Ok(Err(e)) => {
+                debug!(
+                    "auto_detect_baudrate: Failed quality check at {}: {:?}",
+                    rate, e
+                );
+            }
+            Err(_) => {
+                debug!(
+                    "auto_detect_baudrate: Timeout during baudrate check at {}",
+                    rate
+                );
+            }
+        }
+    }
+
+    select_best_baudrate(baudrate_results).ok_or_else(|| {
+        ManagerError::Other(
+            "auto_detect_baudrate: Failed to auto-detect baud rate: No successful communication at any baudrate"
+                .to_string(),
+        )
+    })
+}
+
+async fn test_baudrate_quality(
+    device: &bluerobotics_ping::common::Device,
+    num_checks: usize,
+) -> Result<BaudrateCheckResult, ManagerError> {
+    let mut result = BaudrateCheckResult {
+        messages_received: 0,
+        parser_errors: 0,
+    };
+
+    for _ in 0..num_checks {
+        match timeout(Duration::from_millis(300), device.device_information()).await {
+            Ok(Ok(_)) => {
+                result.messages_received += 1;
+            }
+            Ok(Err(e)) => {
+                debug!("test_baudrate_quality: test_baudrate_quality: {e:?}");
+                result.parser_errors += 1;
+            }
+            Err(e) => {
+                debug!("test_baudrate_quality: test_baudrate_quality: {e:?}");
+                result.parser_errors += 1;
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct BaudrateCheckResult {
+    messages_received: usize,
+    parser_errors: usize,
+}
+
+/// Selects the optimal baudrate from test results based on the following criteria:
+/// 1. Highest number of successful messages received
+/// 2. If tied on messages, lowest number of parser/timeout errors
+/// 3. If tied on both messages and errors, highest baudrate is preferred
+fn select_best_baudrate(results: HashMap<u32, BaudrateCheckResult>) -> Option<u32> {
+    trace!("Starting baudrate selection with {} results", results.len());
+
+    if results.is_empty() {
+        trace!("select_best_baudrate: No baudrate results available");
+        return None;
+    }
+
+    results.iter().for_each(|(rate, result)| {
+        trace!(
+            "select_best_baudrate: Initial baudrate {rate}: {} successful messages, {} parser errors",
+            result.messages_received,
+            result.parser_errors
+        );
+    });
+
+    // Helper to log comparison results
+    fn log_comparison(
+        rate1: u32,
+        result1: &BaudrateCheckResult,
+        rate2: u32,
+        result2: &BaudrateCheckResult,
+        reason: &str,
+        selected: u32,
+    ) {
+        trace!(
+            "select_best_baudrate: Comparing baudrates:\n\
+            {rate1} (messages: {}, errors: {}) vs\n\
+            {rate2} (messages: {}, errors: {})\n\
+            Selected {selected} based on {reason}",
+            result1.messages_received,
+            result1.parser_errors,
+            result2.messages_received,
+            result2.parser_errors,
+        );
+    }
+
+    let selected = results
+        .into_iter()
+        .filter(|(_, result)| result.messages_received > 0)
+        .max_by(|(rate1, result1), (rate2, result2)| {
+            match result1.messages_received.cmp(&result2.messages_received) {
+                std::cmp::Ordering::Equal => {
+                    match result2.parser_errors.cmp(&result1.parser_errors) {
+                        std::cmp::Ordering::Equal => {
+                            trace!(
+                                "select_best_baudrate: Equal messages and errors, selecting higher baudrate {} over {}",
+                                rate1, rate2
+                            );
+                            rate1.cmp(rate2)
+                        }
+                        ordering => {
+                            log_comparison(
+                                *rate1, result1, *rate2, result2,
+                                "error count",
+                                if ordering == std::cmp::Ordering::Greater { *rate1 } else { *rate2 }
+                            );
+                            ordering
+                        }
+                    }
+                }
+                ordering => {
+                    log_comparison(
+                        *rate1, result1, *rate2, result2,
+                        "message count",
+                        if ordering == std::cmp::Ordering::Greater { *rate1 } else { *rate2 }
+                    );
+                    ordering
+                }
+            }
+        })
+        .map(|(rate, result)| {
+            trace!(
+                "select_best_baudrate: Final selection: baudrate {} with {} successful messages and {} errors",
+                rate, result.messages_received, result.parser_errors
+            );
+            rate
+        });
+
+    if selected.is_none() {
+        trace!("select_best_baudrate: No suitable baudrate found after comparison");
+    }
+
+    selected
+}
+
+pub async fn set_baudrate_pre_routine(
+    port: &mut SerialStream,
+    baud_rate: u32,
+) -> Result<(), ManagerError> {
+    timeout(Duration::from_millis(100), async {
+        port.set_baud_rate(baud_rate).map_err(|e| {
+            ManagerError::Other(format!("Failed to set baud rate {}: {}", baud_rate, e))
+        })?;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        port.set_break()
+            .map_err(|e| ManagerError::Other(format!("Failed to set BREAK: {}", e)))?;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        port.clear_break()
+            .map_err(|e| ManagerError::Other(format!("Failed to clear BREAK: {}", e)))?;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        port.write_all(b"U")
+            .await
+            .map_err(|e| ManagerError::Other(format!("Failed to write 'U': {}", e)))?;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        port.flush()
+            .await
+            .map_err(|e| ManagerError::Other(format!("Failed to flush: {}", e)))?;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        port.clear(tokio_serial::ClearBuffer::All)
+            .map_err(|err| ManagerError::DeviceSourceError(err.to_string()))?;
+
+        Ok(())
+    })
+    .await
+    .map_err(|_| ManagerError::Other("set_baudrate_pre_routine: Operation timed out".to_string()))?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
set_baudrate_preroutine method was implemented to make sure that Ping devices successfully communicate at the selected baudrate;

serial_discovery method now iterates through various baudrate values and classify then;

autocreate process optimized and verified with ping1d, ping2, ping360 serial and udp. ( directly and over usb hub )
abnormal behavior found on ping2 answer to check quality, over 100ms ( tested with different ftdi/cables)