### PR TITLE
ping-viewer-next-frontend: Fix: remove background for widgets 

### DIFF
--- a/ping-viewer-next-frontend/src/App.vue
+++ b/ping-viewer-next-frontend/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <template v-if="isWidgetRoute">
-    <v-app class="h-screen w-screen">
+    <v-app class="h-screen w-screen bg-transparent " :theme="theme">
       <router-view />
     </v-app>
   </template>

--- a/ping-viewer-next-frontend/src/components/widgets/sonar1d/Ping1D.vue
+++ b/ping-viewer-next-frontend/src/components/widgets/sonar1d/Ping1D.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col h-full bg-gray-900 p-4" ref="containerRef">
+  <div class="flex flex-col h-full bg-transparent p-4" ref="containerRef">
     <WaterfallDisplay
       :width="width"
       :height="height"

--- a/ping-viewer-next-frontend/src/layouts/default.vue
+++ b/ping-viewer-next-frontend/src/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app>
+  <v-app class="bg-transparent">
     <v-main>
       <router-view />
     </v-main>

--- a/ping-viewer-next-frontend/src/plugins/vuetify.js
+++ b/ping-viewer-next-frontend/src/plugins/vuetify.js
@@ -19,7 +19,7 @@ export default createVuetify({
     VNumberInput,
   },
   theme: {
-    defaultTheme: 'dark',
+    defaultTheme: 'light',
     themes: {
       light: {
         dark: false,


### PR DESCRIPTION
Allow Cockpit to load widgets using iframe.
![image](https://github.com/user-attachments/assets/8c12b0c2-fa71-4cb0-b4a1-f934fc40961e)
