### PR TITLE
ping-viewer-next-frontend: Fix: ping360 update initial range/sector

### DIFF
--- a/ping-viewer-next-frontend/src/pages/addons/widget/[type]/index.vue
+++ b/ping-viewer-next-frontend/src/pages/addons/widget/[type]/index.vue
@@ -114,7 +114,7 @@ export default defineComponent({
         websocketUrl: websocketUrl.value,
         width: dimensions.value.width,
         height: dimensions.value.height,
-        showControls: false,
+        showControls: true,
       };
 
       if (widgetType.value === 'ping360') {


### PR DESCRIPTION
Minor fix, ping360loader can load initial settings.
https://github.com/user-attachments/assets/e1c74481-21a2-4aef-b586-ff6efafea37c

