### PR TITLE
Add: BlueOS Ping integration

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -121,7 +121,7 @@ jobs:
             uses: houseabsolute/actions-rust-cross@v0.0.14
             with:
               target: ${{ matrix.TARGET }}
-              args: "--release --features embed-frontend"
+              args: "--release --features 'embed-frontend blueos-extension'"
 
           - name: Rename
             run: cp target/${{ matrix.TARGET }}/release/${{ github.event.repository.name }}${{ matrix.EXTENSION }} ${{ github.event.repository.name }}-${{ matrix.TARGET }}${{ matrix.EXTENSION }}
@@ -176,7 +176,7 @@ jobs:
             with:
               use-cross: true
               command: build
-              args: --verbose --release --features embed-frontend --target=${{ matrix.TARGET }}
+              args: --verbose --release --features 'embed-frontend blueos-extension' --target=${{ matrix.TARGET }}
           - name: Rename
             run: cp target/${{ matrix.TARGET }}/release/${{ github.event.repository.name }}${{ matrix.EXTENSION }} ${{ github.event.repository.name }}-${{ matrix.TARGET }}${{ matrix.EXTENSION }}
           - uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,8 @@ thiserror = "1.0.63"
 shellexpand = "3.1"
 
 tauri = { version = "1.7.2", optional = true, features = ["shell-open"] }
-
+reqwest = {version = "0.12.12", optional = true, features = ["json"] }
+openssl = { version = "0.10.69", optional = true, features = ["vendored"] }
 
 
 [build-dependencies]
@@ -55,3 +56,4 @@ default = []
 desktop-app = ["tauri", "build-frontend"]
 build-frontend = ["embed-frontend"]
 embed-frontend =[]
+blueos-extension = ["dep:reqwest", "dep:openssl"]


### PR DESCRIPTION
Solves:
https://github.com/bluerobotics/ping-viewer-next/issues/74

`--features blueos-extension `
1. List available bridged ports from the ping service
2. Skip them when probing serial devices
3. Create a UDP device pointing to the ping-bridged one

Preview:
![image](https://github.com/user-attachments/assets/a763ba66-9023-41bd-83f9-3a12703576a0)
![image](https://github.com/user-attachments/assets/690e84e7-14f5-4536-8598-79f5482af2f3)
