### PR TITLE
BlueOS: Improve serial permissions setup and bind logs folder

### DIFF
--- a/blueos-ping-viewer-next/Dockerfile
+++ b/blueos-ping-viewer-next/Dockerfile
@@ -26,7 +26,10 @@ LABEL permissions='{\
   },\
   "HostConfig": {\
     "Privileged": true,\
-    "NetworkMode": "host"\
+    "NetworkMode": "host",\
+    "Binds": [\
+       "/usr/blueos/extensions/ping-viewer-next/logs:/app/logs"\
+    ]\
   }\
 }'
 LABEL authors='[\

--- a/blueos-ping-viewer-next/Dockerfile
+++ b/blueos-ping-viewer-next/Dockerfile
@@ -1,20 +1,23 @@
 FROM alpine:3.18
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash shadow
 
 COPY ./blueos-ping-viewer-next/files/ping-viewer-next.* /
 COPY ./blueos-ping-viewer-next/files/entrypoint.sh /
 
+RUN mkdir -p /app
 RUN chmod +x /entrypoint.sh && \
     if [ "$(uname -m)" = "aarch64" ]; then \
-        cp /ping-viewer-next.aarch64 /ping-viewer-next; \
+        cp /ping-viewer-next.aarch64 /app/ping-viewer-next; \
     elif [ "$(uname -m)" = "x86_64" ]; then \
-        cp /ping-viewer-next.x86_64 /ping-viewer-next; \
+        cp /ping-viewer-next.x86_64 /app/ping-viewer-next; \
     else \
-        cp /ping-viewer-next.armv7 /ping-viewer-next; \
+        cp /ping-viewer-next.armv7 /app/ping-viewer-next; \
     fi && \
-    chmod +x /ping-viewer-next && \
+    chmod +x  /app/ping-viewer-next && \
     rm /ping-viewer-next.*
 LABEL version="0.0.0"
+
+RUN addgroup -g 1000 pingviewer && adduser -G pingviewer -u 1000 pingviewer -D
 
 # Add docker configuration
 LABEL permissions='{\

--- a/blueos-ping-viewer-next/files/entrypoint.sh
+++ b/blueos-ping-viewer-next/files/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -m
 echo "Starting ping viewer next..."
-./ping-viewer-next --enable-auto-create --rest-server 0.0.0.0:6060
+cd app
+su pingviewer -c "./ping-viewer-next --enable-auto-create --rest-server 0.0.0.0:6060"

--- a/blueos-ping-viewer-next/files/entrypoint.sh
+++ b/blueos-ping-viewer-next/files/entrypoint.sh
@@ -2,4 +2,7 @@
 set -m
 echo "Starting ping viewer next..."
 cd app
+mkdir logs
+chmod -R 755 /app/logs
+chown -R pingviewer:pingviewer /app/logs
 su pingviewer -c "./ping-viewer-next --enable-auto-create --rest-server 0.0.0.0:6060"


### PR DESCRIPTION
Fixed permission-related issues for serial devices already in use.
In this case, William observed malfunctions on GPS, which was receiving undesired probing from the serial discovery service.

Docker's default user has root permissions, so this approach creates a user with restricted permissions.
We also found some issues with `binding volumes ` when the user is different from `root`.

1. To solve the issue, we added a new user group for the Alpine container, `pingviewer`
2. Alpine needs a shadow package as it will allow calling su and changing to this new user at runtime (in the entrypoint.sh)
3. Volumes bind normally since they're mounted as root
4. We should document this somewhere (?)

Added logs and volume binding (/usr/blueos/extensions/ping-viewer-next/) following our standard discussed here:
https://github.com/bluerobotics/BlueOS/issues/1640

A nice future improvement would be to allow our log-zipper to see and manipulate this /extensions/*/logs as done on BlueOS.