### PR TITLE
Mention cockpit widget in BlueOS Extension README

### DIFF
--- a/blueos-ping-viewer-next/Dockerfile
+++ b/blueos-ping-viewer-next/Dockerfile
@@ -15,7 +15,7 @@ RUN chmod +x /entrypoint.sh && \
     fi && \
     chmod +x  /app/ping-viewer-next && \
     rm /ping-viewer-next.*
-LABEL version="0.0.0"
+LABEL version="1.0.0-beta.6"
 
 RUN addgroup -g 1000 pingviewer && adduser -G pingviewer -u 1000 pingviewer -D
 
@@ -43,11 +43,11 @@ LABEL company='{\
   "name": "Blue Robotics",\
   "email": "support@bluerobotics.com"\
 }'
-LABEL readme="https://raw.githubusercontent.com/raultrombin/blueos-ping-viewer-next/master/README.md"
-LABEL type="education"
+LABEL readme="https://raw.githubusercontent.com/bluerobotics/ping-viewer-next/refs/heads/master/blueos-ping-viewer-next/README.md"
+LABEL type="device-integration"
 LABEL tags='[\
-  "rov",\
-  "robot"\
+  "sonar",\
+  "ping-protocol"\
 ]'
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/blueos-ping-viewer-next/README.md
+++ b/blueos-ping-viewer-next/README.md
@@ -19,7 +19,7 @@ bluerobotics.ping-viewer-next
 
 Ping Viewer Next
 
-0.0.0
+1.0.0-beta.6
 
 {
   "ExposedPorts": {
@@ -38,3 +38,10 @@ Ping Viewer Next
   }
 }
 ```
+
+### Cockpit Widgets
+
+For each connected ping device, provides a widget accessible through Cockpit as an
+[Automatic External Iframe](https://blueos.cloud/cockpit/docs/latest/usage/advanced/#automatic-external-iframes).
+
+Requires BlueOS >= 1.4.


### PR DESCRIPTION
BlueOS Extension updates:
- Corrects the invalid `type`
- Updates the README link to the one in the new repo
- Updates the version references to the _next_ patch
    - Would be good if the state after merging this can be tagged as `1.0.0-beta.6`
- Updates the README to mention the Cockpit widget functionality
    - Includes the BlueOS version requirement, per @vshie's request