### PR TITLE
Ping360 new firmware

### DIFF
--- a/src/device/manager/discovery_service.rs
+++ b/src/device/manager/discovery_service.rs
@@ -7,7 +7,7 @@ use bluerobotics_ping::ping360::Device as Ping360;
 use tokio::sync::broadcast;
 use tokio::time::sleep;
 use tokio_serial::{SerialPort, SerialPortBuilderExt, SerialStream};
-use tracing::{error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 use udp_stream::UdpStream;
 use uuid::Uuid;
 
@@ -111,6 +111,13 @@ impl DeviceFactory {
                             "Device creation error: Device upgrade attempt {} of {} failed: {err:?}. Retrying...",
                             retry_count, max_retries
                         );
+
+                        debug!("Force stopping device for discovery service next attempt");
+                        match crate::device::manager::turnoff_device_continuous_mode(&source).await {
+                            Ok(()) => debug!("Force stopping device success"),
+                            Err(err) =>
+                                error!("Force stopping device for discovery service next attempt error. Error: {err:?}")
+                        };
 
                         sleep(retry_delay).await;
                         continue;

--- a/src/device/manager/mod.rs
+++ b/src/device/manager/mod.rs
@@ -163,6 +163,7 @@ pub struct DeviceManager {
     receiver: mpsc::Receiver<ManagerActorRequest>,
     pub device: HashMap<Uuid, Device>,
     discovery_service: DiscoveryComponent,
+    pub manager_handler: ManagerActorHandler,
 }
 
 #[derive(Debug)]
@@ -334,15 +335,21 @@ impl DeviceManager {
 
     pub fn new(size: usize) -> (Self, ManagerActorHandler) {
         let (sender, receiver) = mpsc::channel(size);
+
+        let actor_handler = ManagerActorHandler { sender };
         let actor = DeviceManager {
             receiver,
             device: HashMap::new(),
             discovery_service: DiscoveryComponent::new(),
+            manager_handler: actor_handler.clone(),
         };
-        let actor_handler = ManagerActorHandler { sender };
 
         trace!("DeviceManager and handler successfully created: Success");
         (actor, actor_handler)
+    }
+
+    pub fn get_device_manager_handler(&self) -> ManagerActorHandler {
+        self.manager_handler.clone()
     }
 
     pub async fn run(mut self) {


### PR DESCRIPTION
Adds compability with new ping360 firmware,
For now, serial mode will still use the software continuous mode, 
Since it needs a smart way to deal with streams before send it to device creation ( it's missing commands such serial break or othe specific ones), for UDP we dont have this issue as we can send msgs from different threads without any problems.

The BlueOS experience takes advantage of continuous mode since it uses UDP bridged connection.