### PR TITLE
Blueos discovery only udp

### DIFF
--- a/src/device/manager/discovery_service.rs
+++ b/src/device/manager/discovery_service.rs
@@ -203,6 +203,7 @@ impl DeviceDiscoveryManager {
                     }
                 }
 
+                #[cfg(not(feature = "blueos-extension"))]
                 let used_ports: Vec<String> = known_devices
                     .iter()
                     .filter_map(|device| {
@@ -215,6 +216,7 @@ impl DeviceDiscoveryManager {
                     .collect();
 
                 // Add serial devices, skipping used ports
+                #[cfg(not(feature = "blueos-extension"))]
                 if let Some(result) = device_discovery::serial_discovery(Some(&used_ports)).await {
                     for source in result {
                         let key = get_device_key(&source);


### PR DESCRIPTION
For BlueOS extension, ping-viewer-next will let ping service handle devices.