### PR TITLE
ping-viewer-next-frontend: widgets: Fix transparent background issues

### DIFF
--- a/ping-viewer-next-frontend/src/App.vue
+++ b/ping-viewer-next-frontend/src/App.vue
@@ -14,10 +14,18 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, watchEffect } from 'vue';
 import { useRoute } from 'vue-router';
+import { useTheme } from 'vuetify';
 import MainView from './views/Main.vue';
 
 const route = useRoute();
 const isWidgetRoute = computed(() => route.path.startsWith('/addons/widget/'));
+const theme = useTheme();
+
+watchEffect(() => {
+  if (isWidgetRoute.value) {
+    theme.global.name.value = 'light';
+  }
+});
 </script>


### PR DESCRIPTION
Quick fix to avoid darkmode=true.
With this, we have widget transparency back to working as expected on cockpit.

![image](https://github.com/user-attachments/assets/a0993821-488b-4469-a82b-373076033469)
