### PR TITLE
blueos-extension: Dockerfile: Fix, add recordings folder permission

### DIFF
--- a/blueos-ping-viewer-next/Dockerfile
+++ b/blueos-ping-viewer-next/Dockerfile
@@ -28,7 +28,8 @@ LABEL permissions='{\
     "Privileged": true,\
     "NetworkMode": "host",\
     "Binds": [\
-       "/usr/blueos/extensions/ping-viewer-next/logs:/app/logs"\
+       "/usr/blueos/extensions/ping-viewer-next/logs:/app/logs",\
+       "/usr/blueos/extensions/ping-viewer-next/recordings:/app/recordings"\
     ]\
   }\
 }'

--- a/blueos-ping-viewer-next/files/entrypoint.sh
+++ b/blueos-ping-viewer-next/files/entrypoint.sh
@@ -3,6 +3,9 @@ set -m
 echo "Starting ping viewer next..."
 cd app
 mkdir logs
+mkdir recordings
 chmod -R 755 /app/logs
+chmod -R 755 /app/recordings
 chown -R pingviewer:pingviewer /app/logs
+chown -R pingviewer:pingviewer /app/recordings
 su pingviewer -c "./ping-viewer-next --enable-auto-create --rest-server 0.0.0.0:6060"


### PR DESCRIPTION
Same logic we used for logs folder,
recordings are binded and available to container.