### PR TITLE
Frontend: Components: Widgets: Ping360Shader: Allow adaptative array lenght

### DIFF
--- a/ping-viewer-next-frontend/src/components/widgets/sonar360/Ping360.vue
+++ b/ping-viewer-next-frontend/src/components/widgets/sonar360/Ping360.vue
@@ -6,9 +6,9 @@
 				:radiusLineColor="radiusLineColor" :markerColor="markerColor"
 				:markerBackgroundColor="markerBackgroundColor" :radiusLineWidth="radiusLineWidth"
 				:startAngle="startAngle" :endAngle="endAngle">
-				<Sonar360Shader :measurement="measurement" :numLines="400" :lineLength="1202"
-					:color-palette="colorPalette" :get-color-from-palette="getColorFromPalette" :startAngle="startAngle"
-					:endAngle="endAngle" :yaw_angle="yaw_angle" :debug=false />
+			<Sonar360Shader :measurement="measurement" :numLines="400"
+				:color-palette="colorPalette" :get-color-from-palette="getColorFromPalette" :startAngle="startAngle"
+				:endAngle="endAngle" :yaw_angle="yaw_angle" :debug=false />
 			</Sonar360Mask>
 		</div>
 


### PR DESCRIPTION
This PR fixes a shader issue related to different array sizes and adds the capability to accept values other than 1200, 
fixing issues when using lesser values such 200 and eventually enabling a desired feature like +5000 points.

Before: 10m scan with 200 points - shader not using entire screen and not matching the current value of Range (should be using entire screen).
Now: Shader using entire space with different measurement size manually set by user, example: 200.
<img width="2548" height="971" alt="image" src="https://github.com/user-attachments/assets/408da948-e64d-4de7-882a-875531363432" />

Test with 5000 points, desired behavier available at right.
<img width="2548" height="971" alt="image" src="https://github.com/user-attachments/assets/01af4f8c-1ca2-437b-a114-da4c333edc7a" />

