### PR TITLE
github: action: Add tauri assets to release tag

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -305,6 +305,9 @@ jobs:
               with:
                 projectPath: './ping-viewer-next-desktop'
                 args: ${{ matrix.args }}
+                tagName: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
+                releaseName: ${{ startsWith(github.ref, 'refs/tags/') && format('Ping Viewer 2 qv{0}', github.ref_name) || '' }}
+                releaseDraft: false
 
             - name: Upload artifacts
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
https://github.com/RaulTrombin/ping-viewer-next/releases/tag/v0.0.21 tested here
<img width="1220" height="584" alt="image" src="https://github.com/user-attachments/assets/9df1080e-30c6-4378-9100-a45a16b32aa5" />
